### PR TITLE
Add github workspace as safe directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 cd "$GITHUB_WORKSPACE"
 
-git config --global --add safe.directory $GITHUB_WORKSPACE
+git config --global --add safe.directory $GITHUB_WORKSPACE || exit 1
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 cd "$GITHUB_WORKSPACE"
 
+git config --global --add safe.directory $GITHUB_WORKSPACE
+
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 fasterer | sed "s/\x1b\[[0-9;]*m//g" \


### PR DESCRIPTION
Git v2.35.2 changes are causing action-fasterer to error during run.


Related issues: 
- https://github.com/reviewdog/reviewdog/issues/1158
- https://github.blog/2022-04-12-git-security-vulnerability-announced
- https://github.com/reviewdog/action-yamllint/issues/18

This fix takes the same approach many of the other repositories have taken.
